### PR TITLE
use more openssl tools (portability)

### DIFF
--- a/hpkp-gen
+++ b/hpkp-gen
@@ -18,23 +18,25 @@ if [ "$1" = "" ]; then
 	exit 1
 fi
 
-head="Public-Key-Pins: max-age=5184000; "
+head="Public-Key-Pins: max-age=5184000;"
 
 c=0
 for f in "$@"; do
+	pubkeyfile=`mktemp -t hpkp`
 	if [ "${f: -4}" = ".crt" ]; then
-		pkey=`openssl x509 -pubkey -noout -in $f`
+		openssl x509 -pubkey -noout -in $f | openssl asn1parse -inform pem -noout -out $pubkeyfile
 	elif [ "${f: -4}" = ".csr" ]; then
-		pkey=`openssl req -pubkey -noout -in $f`
+		openssl req -pubkey -noout -in $f | openssl asn1parse -inform pem -noout -out $pubkeyfile
 	elif [ "${f: -4}" = ".key" ]; then
-		pkey=`openssl pkey -in $f -pubout`
+		openssl pkey -in $f -pubout | openssl asn1parse -inform pem -noout -out $pubkeyfile
 	else
 		echo "$f is not a valid file format"
 		exit -1
 	fi
 	let c+=1
-	phash=`echo "$pkey"|grep -v PUBLIC|base64 -d|sha256sum |xxd -r -p|base64`
-	head="${head}pin-sha256=\"$phash\";"
+	phash=`openssl dgst -sha256 -binary $pubkeyfile | base64`
+	head="${head} pin-sha256=\"$phash\";"
+	rm $pubkeyfile
 done
 
 [ $c -eq 1 ] && echo "Warning: HKP requires at least 2 keys" >&2


### PR DESCRIPTION
On at least OSX, I'm getting bad output from the example data:

Public-Key-Pins: max-age=5184000; pin-sha256="HWqQWajyRtiiXL5w0V4Xq5I9jrR8knuwXYGaTqN1vrE=";pin-sha256="3GvMoKbahfHC8K6s8zwhRDNlZ1Z8nvx6fhCRCixQPhk=";

I can also verify by following the recommendations in the upstream spec (http://tools.ietf.org/html/draft-ietf-websec-key-pinning-20#appendix-A) that this tool outputs different results from the example script in the spec, when running on OSX.

Note that this is _after_ altering the hpkp-gen script to call "gsha256sum" from the Homebrew-installed "coreutils" package... there isn't a stock "sha256sum" to call.

This changes hpkp-gen to be more like the reference spec, which uses only openssl-supplied tools plus "base64", and thus is likely more portable. Indeed it does work properly on OSX.

The downside is it requires temp files, as both "openssl asn1parse" and "openssl dgst" are not pipe-friendly (the former won't output to a pipe, and the latter won't read from one). I've opted for the very simple "mktemp" to handle this.
