### PR TITLE
Updated for IETF RFC and BSD compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ and certificate requests (.csr).
 More Info
 =========
 
-* [Public Key Pinning Extension for HTTP draft-ietf-websec-key-pinning-21](https://tools.ietf.org/html/draft-ietf-websec-key-pinning-20)
+* [Public Key Pinning Extension for HTTP - RFC 7469](https://tools.ietf.org/html/rfc7469)

--- a/hpkp-gen
+++ b/hpkp-gen
@@ -33,7 +33,7 @@ for f in "$@"; do
 		exit -1
 	fi
 	let c+=1
-	phash=$(echo -n "$pkey"|grep -v PUBLIC|base64 -d|openssl dgst -sha256 -binary|base64|tr -d "\r\n")
+	phash=$(echo -n "$pkey"|grep -v PUBLIC|base64 -d 2>/dev/null|openssl dgst -sha256 -binary|base64|tr -d "\r\n")
 	head="${head}pin-sha256=\"${phash}\";"
 done
 

--- a/hpkp-gen
+++ b/hpkp-gen
@@ -8,7 +8,7 @@
 
 if [ "$1" = "" ]; then
 	echo "HKP header generator according to"
-	echo "http://tools.ietf.org/html/draft-ietf-websec-key-pinning-20"
+	echo "https://tools.ietf.org/html/rfc7469"
 	echo ""
 	echo "Usage: $0 [files]"
 	echo ""

--- a/hpkp-gen
+++ b/hpkp-gen
@@ -23,18 +23,18 @@ head="Public-Key-Pins: max-age=5184000; "
 c=0
 for f in "$@"; do
 	if [ "${f: -4}" = ".crt" ]; then
-		pkey=`openssl x509 -pubkey -noout -in $f`
+		pkey=$(openssl x509 -pubkey -noout -in "$f")
 	elif [ "${f: -4}" = ".csr" ]; then
-		pkey=`openssl req -pubkey -noout -in $f`
+		pkey=$(openssl req -pubkey -noout -in "$f")
 	elif [ "${f: -4}" = ".key" ]; then
-		pkey=`openssl pkey -in $f -pubout`
+		pkey=$(openssl pkey -in "$f" -pubout)
 	else
 		echo "$f is not a valid file format"
 		exit -1
 	fi
 	let c+=1
-	phash=`echo "$pkey"|grep -v PUBLIC|base64 -d|openssl dgst -sha256 -binary|base64`
-	head="${head}pin-sha256=\"$phash\";"
+	phash=$(echo -n "$pkey"|grep -v PUBLIC|base64 -d|openssl dgst -sha256 -binary|base64|tr -d "\r\n")
+	head="${head}pin-sha256=\"${phash}\";"
 done
 
 [ $c -eq 1 ] && echo "Warning: HKP requires at least 2 keys" >&2


### PR DESCRIPTION
Updated the references from HPKP drafts to the released standards track RFC.

Changed backticks to more modern $(syntax).
Paths with spaces should be handled more gracefully now.

Now also works on OS X and FreeBSD 10.1 with different base64 binaries common to those platforms. Made sure I didn't break compatibility with Debian Wheezy.
